### PR TITLE
fix -metadata.json path

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -240,9 +240,13 @@ func RMFiler(inputpath string, template string, isTemplateBundle bool) (RMFileIn
 
 		err := checkFileExists(rmJSONPath)
 		if err != nil {
-			rmP.Exists = false
-			rm.Pages = append(rm.Pages, rmP)
-			continue
+			rmJSONPath = filepath.Join(fbase, fmt.Sprintf("%d-metadata.json", i))
+			err := checkFileExists(rmJSONPath)
+			if err != nil {
+				rmP.Exists = false
+				rm.Pages = append(rm.Pages, rmP)
+				continue
+			}
 		}
 
 		err = checkFileExists(rmPath)


### PR DESCRIPTION
A small backward compatible change to use rm2pdf within the reMarkable app directory on recent versions : if the metadata JSON file for a page is not found, try another naming scheme (page number instead of UUID).